### PR TITLE
Add Apprise integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,19 @@ In case of any errors make sure you're using the correct paths and "freenom.conf
 
 ## Email Notifications
 
-To enable email alerts make sure `MTA` is set, the default is 'sendmail'. Emails will be send on renew or update errors. If you do not have/want an MTA installed you could use [bashmail](https://git.io/JJdto) instead.
+To enable email alerts, make sure `MTA` is set; the default is `/usr/sbin/sendmail`. Emails will be sent on renewal or update errors. If you do not have/want an MTA installed you could use [bashmail](https://git.io/JJdto) instead.
 
 If you want to receive the alerts on a different email address than `freenom_email` set `RCPTTO`. You can also set an optional "From" address: `MAILFROM="Freenom Script <freenom-script@example.tk>"`
 
 Leaving `MTA` empty or commented disables alerts.
 
+## Apprise Notifications
+
+To enable [Apprise](https://github.com/caronc/apprise) notifications, make sure `APPRISE` is set to the location where you installed the Apprise CLI; the default is `/usr/local/bin/apprise`. You must also set the `APPRISE_SERVER_URLS` array to contain one or more server URLs; notifications are sent to all of the listed server URLs. As with email notifications, Apprise notifications are sent on renewal or update errors.
+
+For details on how to construct server URLs, refer to https://github.com/caronc/apprise/blob/master/README.md.
+
+Leaving the `APPRISE_SERVER_URLS` array empty disables Apprise notifications.
 
 ### Optional Overrides
 

--- a/freenom.conf
+++ b/freenom.conf
@@ -111,6 +111,22 @@ MTA="/usr/sbin/sendmail"
 # Optional e-mail address from which to sent notifications ("From:"). Default is none
 #MAILFROM="Freenom Script <freenom-script@example.com>"
 
+###########
+# Apprise #
+###########
+
+# Path to Apprise CLI binary.
+APPRISE="/usr/local/bin/apprise"
+
+# Apprise server URLs. This is a Bash array -- server URLs should go on separate
+# lines, with no commas between URLs. For service IDs and URL syntax, refer to:
+# https://github.com/caronc/apprise/blob/master/README.md
+APPRISE_SERVER_URLS=(
+    # "service_id1://..."
+    # "service_id2://..."
+    # ...
+)
+
 ######################
 # Domain name and id #
 ######################

--- a/freenom.sh
+++ b/freenom.sh
@@ -496,6 +496,27 @@ mailEvent() {
   fi
 }
 
+# Function appriseEvent: send Apprise notification
+#         parameters: $1: event 2: $messages
+appriseEvent() {
+  if [ "${#APPRISE_SERVER_URLS[@]}" -gt 0 ]; then
+    if [ "$debug" -ge 1 ]; then
+      echo "DEBUG: $(date '+%H:%M:%S') apprise $pad4   HOSTNAME=$HOSTNAME APPRISE=$APPRISE APPRISE_SERVER_URLS=(${APPRISE_SERVER_URLS[@]}) 1=$1 2=$2"
+    fi
+    if [ "$debug" -ge 3 ]; then
+      set -x
+    fi
+    "$APPRISE" --title "freenom.sh: \"$1\" on \"$HOSTNAME\"" --body "$2" "${APPRISE_SERVER_URLS[@]}"
+    EXITCODE="$?"
+    if [ "$EXITCODE" -ne 0 ]; then
+      echo "Error: exit code \"$EXITCODE\" while running $APPRISE"
+    fi
+    if [ "$debug" -ge 3 ]; then
+      set +x
+    fi
+  fi
+}
+
 # debug functions
 
 # Function debugHttp: show curl error
@@ -1609,6 +1630,7 @@ if [ "$freenom_update_ip" -eq 1 ]; then
     eMsg="Update(s) using \"${currentIp}\" failed: ${updateError}"
     echo -e "[$(date)] $eMsg" >> "${out_path}.log"
     mailEvent UpdateError "$eMsg"
+    appriseEvent UpdateError "$eMsg"
   fi
 fi
 
@@ -1634,6 +1656,7 @@ if [ "$freenom_renew_domain" -eq 1 ]; then
     eMsg="These domain(s) failed to renew: ${renewError}"
     echo -e "[$(date)] $eMsg" >> "${out_path}.log"
     mailEvent RenewError "$eMsg"
+    appriseEvent RenewError "$eMsg"
   fi
 fi
 


### PR DESCRIPTION
Apprise (https://github.com/caronc/apprise) makes it possible to send
notifications via a number of popular services. The Apprise CLI must be
installed separately for this integration to work.