### PR TITLE
new arg `-U` for updating fulldomain

### DIFF
--- a/freenom.sh
+++ b/freenom.sh
@@ -261,6 +261,11 @@ func_getDomainArgs () {
     _subdom_set=1
   fi
 
+  local _fulldom_set=0
+  if printf -- "%s" "$*" | grep -Eq -- '(^|[^a-zA-Z])\-U'; then
+    _fulldom_set=1
+  fi
+
   # first remove debug arg
   _d_args="$( echo "$*" | sed -E 's/ ?-debug ([0-9])//' )"
 
@@ -283,6 +288,15 @@ func_getDomainArgs () {
   fi
   _arg_domain_id="$( echo "$_d_args" | sed -n -E 's/.*([0-9]{10}+).*/\1/p' )"
   _arg_subdomain_name="$( echo "$_d_args" | sed -n -E 's/.*-s ([^ ]+).*/\1/p' )"
+
+  # split subdomain from fulldomain
+  if [ "$_fulldom_set" -ge 1 ] && [ "$_subdom_set" -eq 0 ]; then
+    if [ "$(( 0 + $(echo "$_arg_domain_name" | tr '.' '\n' | wc -l) ))" -ge 3 ]; then
+      _subdom_set=1
+      _arg_subdomain_name="$( echo "$_arg_domain_name" | sed -n -E 's/^([0-9a-zA-Z]*)\..*/\1/p' )"
+      _arg_domain_name="$( echo "$_arg_domain_name" | sed -n -E 's/^[0-9a-z]*\.(.*)/\1/p' )"
+    fi
+  fi
 
   # if domain arg is not empty use that instead of setting from conf
   if [[ -n "$freenom_update_all" && "$freenom_update_all" -eq 0 ]]; then

--- a/freenom.sh
+++ b/freenom.sh
@@ -293,8 +293,8 @@ func_getDomainArgs () {
   if [ "$_fulldom_set" -ge 1 ] && [ "$_subdom_set" -eq 0 ]; then
     if [ "$(( 0 + $(echo "$_arg_domain_name" | tr '.' '\n' | wc -l) ))" -ge 3 ]; then
       _subdom_set=1
-      _arg_subdomain_name="$( echo "$_arg_domain_name" | sed -n -E 's/^([0-9a-zA-Z]*)\..*/\1/p' )"
-      _arg_domain_name="$( echo "$_arg_domain_name" | sed -n -E 's/^[0-9a-z]*\.(.*)/\1/p' )"
+      _arg_subdomain_name="$( echo "$_arg_domain_name" | sed -n -E 's/^([0-9a-zA-Z\-]*)\..*/\1/p' )"
+      _arg_domain_name="$( echo "$_arg_domain_name" | sed -n -E 's/^[0-9a-zA-Z\-]*\.(.*)/\1/p' )"
     fi
   fi
 

--- a/systemd/freenom-update@.service
+++ b/systemd/freenom-update@.service
@@ -3,4 +3,4 @@ Description="Update ip of freenom domain %I"
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/freenom.sh -u %I
+ExecStart=/usr/local/bin/freenom.sh -U %I


### PR DESCRIPTION
Currently, the command to update the subdomain record is as follows:
```bash
freenom.sh -u example.tk -s sub
```
which is not handled by the *systemd* timer file:
```bash
systemctl enable freenom-update@sub.example.tk.timer # did NOT work in the past
```
To solve this problem, a new argument `-U` is added to parse the full domain *sub.example.tk*.
Therefore, the above command can be:
```bash
freenom.sh -U sub.example.tk
```
And the *systemd* timer file can be simply enabled as:
```bash
systemctl enable freenom-update@sub.example.tk.timer # start working now
```